### PR TITLE
rust-postgres: add blocking replication API

### DIFF
--- a/postgres/Cargo.toml
+++ b/postgres/Cargo.toml
@@ -35,6 +35,7 @@ bytes = "1.0"
 fallible-iterator = "0.2"
 futures = "0.3"
 tokio-postgres = { version = "0.7.1", path = "../tokio-postgres" }
+postgres-protocol = { version = "0.6.1", path = "../postgres-protocol" }
 
 tokio = { version = "1.0", features = ["rt", "time"] }
 log = "0.4"

--- a/postgres/src/client.rs
+++ b/postgres/src/client.rs
@@ -1,6 +1,6 @@
 use crate::connection::Connection;
 use crate::{
-    CancelToken, Config, CopyInWriter, CopyOutReader, Notifications, RowIter, Statement,
+    CancelToken, Config, CopyBoth, CopyInWriter, CopyOutReader, Notifications, RowIter, Statement,
     ToStatement, Transaction, TransactionBuilder,
 };
 use std::task::Poll;
@@ -393,6 +393,15 @@ impl Client {
     {
         let stream = self.connection.block_on(self.client.copy_out(query))?;
         Ok(CopyOutReader::new(self.connection.as_ref(), stream))
+    }
+
+    /// Executes a CopyBoth query, returning a combined Stream+Sink type to read and write copy
+    /// data.
+    pub fn copy_both_simple(&mut self, query: &str) -> Result<CopyBoth<'_>, Error> {
+        let stream = self
+            .connection
+            .block_on(self.client.copy_both_simple(query))?;
+        Ok(CopyBoth::new(self.connection.as_ref(), stream))
     }
 
     /// Executes a sequence of SQL statements using the simple query protocol.

--- a/postgres/src/copy_both.rs
+++ b/postgres/src/copy_both.rs
@@ -1,0 +1,77 @@
+use crate::connection::ConnectionRef;
+use crate::lazy_pin::LazyPin;
+use bytes::{Buf, Bytes, BytesMut};
+use futures::{SinkExt, StreamExt};
+use std::io::{self, BufRead, Read};
+use tokio_postgres::{CopyBothDuplex, Error};
+
+/// The reader/writer returned by the `copy_both_simple` method.
+pub struct CopyBoth<'a> {
+    pub(crate) connection: ConnectionRef<'a>,
+    pub(crate) stream_sink: LazyPin<CopyBothDuplex<Bytes>>,
+    buf: BytesMut,
+    cur: Bytes,
+}
+
+impl<'a> CopyBoth<'a> {
+    pub(crate) fn new(
+        connection: ConnectionRef<'a>,
+        duplex: CopyBothDuplex<Bytes>,
+    ) -> CopyBoth<'a> {
+        CopyBoth {
+            connection,
+            stream_sink: LazyPin::new(duplex),
+            buf: BytesMut::new(),
+            cur: Bytes::new(),
+        }
+    }
+
+    /// Completes the copy, returning the number of rows written.
+    ///
+    /// If this is not called, the copy will be aborted.
+    pub fn finish(mut self) -> Result<u64, Error> {
+        self.flush_inner()?;
+        self.connection.block_on(self.stream_sink.pinned().finish())
+    }
+
+    fn flush_inner(&mut self) -> Result<(), Error> {
+        if self.buf.is_empty() {
+            return Ok(());
+        }
+
+        self.connection
+            .block_on(self.stream_sink.pinned().send(self.buf.split().freeze()))
+    }
+}
+
+impl Read for CopyBoth<'_> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let b = self.fill_buf()?;
+        let len = usize::min(buf.len(), b.len());
+        buf[..len].copy_from_slice(&b[..len]);
+        self.consume(len);
+        Ok(len)
+    }
+}
+
+impl BufRead for CopyBoth<'_> {
+    fn fill_buf(&mut self) -> io::Result<&[u8]> {
+        while !self.cur.has_remaining() {
+            let mut stream = self.stream_sink.pinned();
+            match self
+                .connection
+                .block_on(async { stream.next().await.transpose() })
+            {
+                Ok(Some(cur)) => self.cur = cur,
+                Err(e) => return Err(io::Error::new(io::ErrorKind::Other, e)),
+                Ok(None) => break,
+            };
+        }
+
+        Ok(&self.cur)
+    }
+
+    fn consume(&mut self, amt: usize) {
+        self.cur.advance(amt);
+    }
+}

--- a/postgres/src/lib.rs
+++ b/postgres/src/lib.rs
@@ -72,6 +72,7 @@ pub use tokio_postgres::{
 pub use crate::cancel_token::CancelToken;
 pub use crate::client::*;
 pub use crate::config::Config;
+pub use crate::copy_both::CopyBoth;
 pub use crate::copy_in_writer::CopyInWriter;
 pub use crate::copy_out_reader::CopyOutReader;
 #[doc(no_inline)]
@@ -92,14 +93,18 @@ mod cancel_token;
 mod client;
 pub mod config;
 mod connection;
+mod copy_both;
 mod copy_in_writer;
 mod copy_out_reader;
 mod generic_client;
 mod lazy_pin;
 pub mod notifications;
+pub mod replication;
 mod row_iter;
 mod transaction;
 mod transaction_builder;
 
+#[cfg(test)]
+mod replication_test;
 #[cfg(test)]
 mod test;

--- a/postgres/src/replication.rs
+++ b/postgres/src/replication.rs
@@ -1,0 +1,164 @@
+//! Utilities for working with the PostgreSQL replication copy both format.
+
+use crate::connection::ConnectionRef;
+use crate::lazy_pin::LazyPin;
+use crate::{CopyBoth, Error};
+use bytes::Bytes;
+use fallible_iterator::FallibleIterator;
+use futures::Stream;
+use postgres_protocol::message::backend::{LogicalReplicationMessage, ReplicationMessage};
+use std::task::Poll;
+use std::time::SystemTime;
+use tokio_postgres::replication::{LogicalReplicationStream, ReplicationStream};
+use tokio_postgres::types::PgLsn;
+
+/// A type which deserializes the postgres replication protocol.
+///
+/// This type can be used with both physical and logical replication to get
+/// access to the byte content of each replication message.
+///
+/// This is the sync (blocking) version of [`ReplicationStream`]
+pub struct ReplicationIter<'a> {
+    connection: ConnectionRef<'a>,
+    stream: LazyPin<ReplicationStream>,
+}
+
+impl<'a> ReplicationIter<'a> {
+    /// Creates a new `ReplicationIter`.
+    pub fn new(copyboth: CopyBoth<'a>) -> Self {
+        let unpinned_copyboth = copyboth
+            .stream_sink
+            .into_unpinned()
+            .expect("copy-both stream has already been used");
+        let stream = ReplicationStream::new(unpinned_copyboth);
+        Self {
+            connection: copyboth.connection,
+            stream: LazyPin::new(stream),
+        }
+    }
+
+    /// Send standby update to server.
+    pub fn standby_status_update(
+        &mut self,
+        write_lsn: PgLsn,
+        flush_lsn: PgLsn,
+        apply_lsn: PgLsn,
+        timestamp: SystemTime,
+        reply: u8,
+    ) -> Result<(), Error> {
+        self.connection.block_on(
+            self.stream
+                .pinned()
+                .standby_status_update(write_lsn, flush_lsn, apply_lsn, timestamp, reply),
+        )
+    }
+
+    /// Send hot standby feedback message to server.
+    pub fn hot_standby_feedback(
+        &mut self,
+        timestamp: SystemTime,
+        global_xmin: u32,
+        global_xmin_epoch: u32,
+        catalog_xmin: u32,
+        catalog_xmin_epoch: u32,
+    ) -> Result<(), Error> {
+        self.connection
+            .block_on(self.stream.pinned().hot_standby_feedback(
+                timestamp,
+                global_xmin,
+                global_xmin_epoch,
+                catalog_xmin,
+                catalog_xmin_epoch,
+            ))
+    }
+}
+
+impl<'a> FallibleIterator for ReplicationIter<'a> {
+    type Item = ReplicationMessage<Bytes>;
+    type Error = Error;
+
+    fn next(&mut self) -> Result<Option<Self::Item>, Self::Error> {
+        let pinstream = &mut self.stream;
+
+        self.connection
+            .poll_block_on(|cx, _, _| match pinstream.pinned().poll_next(cx) {
+                Poll::Ready(x) => Poll::Ready(x.transpose()),
+                Poll::Pending => Poll::Pending,
+            })
+    }
+}
+
+/// A type which deserializes the postgres logical replication protocol. This
+/// type gives access to a high level representation of the changes in
+/// transaction commit order.
+///
+/// This is the sync (blocking) version of [`LogicalReplicationStream`]
+pub struct LogicalReplicationIter<'a> {
+    connection: ConnectionRef<'a>,
+    stream: LazyPin<LogicalReplicationStream>,
+}
+
+impl<'a> LogicalReplicationIter<'a> {
+    /// Creates a new `ReplicationThing`.
+    pub fn new(copyboth: CopyBoth<'a>) -> Self {
+        let unpinned_copyboth = copyboth
+            .stream_sink
+            .into_unpinned()
+            .expect("copy-both stream has already been used");
+        let stream = LogicalReplicationStream::new(unpinned_copyboth);
+        Self {
+            connection: copyboth.connection,
+            stream: LazyPin::new(stream),
+        }
+    }
+
+    /// Send standby update to server.
+    pub fn standby_status_update(
+        &mut self,
+        write_lsn: PgLsn,
+        flush_lsn: PgLsn,
+        apply_lsn: PgLsn,
+        timestamp: SystemTime,
+        reply: u8,
+    ) -> Result<(), Error> {
+        self.connection.block_on(
+            self.stream
+                .pinned()
+                .standby_status_update(write_lsn, flush_lsn, apply_lsn, timestamp, reply),
+        )
+    }
+
+    /// Send hot standby feedback message to server.
+    pub fn hot_standby_feedback(
+        &mut self,
+        timestamp: SystemTime,
+        global_xmin: u32,
+        global_xmin_epoch: u32,
+        catalog_xmin: u32,
+        catalog_xmin_epoch: u32,
+    ) -> Result<(), Error> {
+        self.connection
+            .block_on(self.stream.pinned().hot_standby_feedback(
+                timestamp,
+                global_xmin,
+                global_xmin_epoch,
+                catalog_xmin,
+                catalog_xmin_epoch,
+            ))
+    }
+}
+
+impl<'a> FallibleIterator for LogicalReplicationIter<'a> {
+    type Item = ReplicationMessage<LogicalReplicationMessage>;
+    type Error = Error;
+
+    fn next(&mut self) -> Result<Option<Self::Item>, Self::Error> {
+        let pinstream = &mut self.stream;
+
+        self.connection
+            .poll_block_on(|cx, _, _| match pinstream.pinned().poll_next(cx) {
+                Poll::Ready(x) => Poll::Ready(x.transpose()),
+                Poll::Pending => Poll::Pending,
+            })
+    }
+}

--- a/postgres/src/replication_test.rs
+++ b/postgres/src/replication_test.rs
@@ -1,0 +1,135 @@
+use crate::replication::LogicalReplicationIter;
+use crate::{Client, SimpleQueryMessage};
+use fallible_iterator::FallibleIterator;
+use postgres_protocol::message::backend::{
+    LogicalReplicationMessage, ReplicationMessage, TupleData,
+};
+use std::time::SystemTime;
+use tokio_postgres::types::PgLsn;
+use tokio_postgres::NoTls;
+
+#[test]
+fn replication() {
+    use LogicalReplicationMessage::{Begin, Commit, Insert};
+    use ReplicationMessage::{PrimaryKeepAlive, XLogData};
+    use SimpleQueryMessage::Row;
+
+    let mut client = Client::connect(
+        "host=localhost port=5433 user=postgres replication=database",
+        NoTls,
+    )
+    .unwrap();
+
+    client
+        .simple_query("DROP TABLE IF EXISTS test_logical_replication")
+        .unwrap();
+    client
+        .simple_query("CREATE TABLE test_logical_replication(i int)")
+        .unwrap();
+    let res = client
+        .simple_query("SELECT 'test_logical_replication'::regclass::oid")
+        .unwrap();
+    let rel_id: u32 = if let Row(row) = &res[0] {
+        row.get("oid").unwrap().parse().unwrap()
+    } else {
+        panic!("unexpeced query message");
+    };
+
+    client
+        .simple_query("DROP PUBLICATION IF EXISTS test_pub")
+        .unwrap();
+    client
+        .simple_query("CREATE PUBLICATION test_pub FOR ALL TABLES")
+        .unwrap();
+
+    let slot = "test_logical_slot";
+
+    let query = format!(
+        r#"CREATE_REPLICATION_SLOT {:?} TEMPORARY LOGICAL "pgoutput""#,
+        slot
+    );
+    let slot_query = client.simple_query(&query).unwrap();
+    let lsn = if let Row(row) = &slot_query[0] {
+        row.get("consistent_point").unwrap()
+    } else {
+        panic!("unexpeced query message");
+    };
+
+    // issue a query that will appear in the slot's stream since it happened after its creation
+    client
+        .simple_query("INSERT INTO test_logical_replication VALUES (42)")
+        .unwrap();
+
+    let options = r#"("proto_version" '1', "publication_names" 'test_pub')"#;
+    let query = format!(
+        r#"START_REPLICATION SLOT {:?} LOGICAL {} {}"#,
+        slot, lsn, options
+    );
+    let copy_stream = client.copy_both_simple(query.as_str()).unwrap();
+
+    let mut stream = LogicalReplicationIter::new(copy_stream);
+
+    // verify that we can observe the transaction in the replication stream
+    let begin = loop {
+        match stream.next() {
+            Ok(Some(XLogData(body))) => {
+                if let Begin(begin) = body.into_data() {
+                    break begin;
+                }
+            }
+            Ok(Some(_)) => (),
+            Ok(None) => panic!("unexpected replication stream end"),
+            Err(_) => panic!("unexpected replication stream error"),
+        }
+    };
+
+    let insert = loop {
+        match stream.next() {
+            Ok(Some(XLogData(body))) => {
+                if let Insert(insert) = body.into_data() {
+                    break insert;
+                }
+            }
+            Ok(Some(_)) => (),
+            Ok(None) => panic!("unexpected replication stream end"),
+            Err(_) => panic!("unexpected replication stream error"),
+        }
+    };
+
+    let commit = loop {
+        match stream.next() {
+            Ok(Some(XLogData(body))) => {
+                if let Commit(commit) = body.into_data() {
+                    break commit;
+                }
+            }
+            Ok(Some(_)) => (),
+            Ok(None) => panic!("unexpected replication stream end"),
+            Err(_) => panic!("unexpected replication stream error"),
+        }
+    };
+
+    assert_eq!(begin.final_lsn(), commit.commit_lsn());
+    assert_eq!(insert.rel_id(), rel_id);
+
+    let tuple_data = insert.tuple().tuple_data();
+    assert_eq!(tuple_data.len(), 1);
+    assert!(matches!(tuple_data[0], TupleData::Text(_)));
+    if let TupleData::Text(data) = &tuple_data[0] {
+        assert_eq!(data, &b"42"[..]);
+    }
+
+    // Send a standby status update and require a keep alive response
+    let lsn: PgLsn = lsn.parse().unwrap();
+    stream
+        .standby_status_update(lsn, lsn, lsn, SystemTime::now(), 1)
+        .unwrap();
+    loop {
+        match stream.next() {
+            Ok(Some(PrimaryKeepAlive(_))) => break,
+            Ok(Some(_)) => (),
+            Ok(None) => panic!("unexpected replication stream end"),
+            Err(e) => panic!("unexpected replication stream error: {}", e),
+        }
+    }
+}

--- a/tokio-postgres/src/lib.rs
+++ b/tokio-postgres/src/lib.rs
@@ -119,6 +119,7 @@ pub use crate::cancel_token::CancelToken;
 pub use crate::client::Client;
 pub use crate::config::Config;
 pub use crate::connection::Connection;
+pub use crate::copy_both::CopyBothDuplex;
 pub use crate::copy_in::CopyInSink;
 pub use crate::copy_out::CopyOutStream;
 use crate::error::DbError;

--- a/tokio-postgres/src/replication.rs
+++ b/tokio-postgres/src/replication.rs
@@ -23,7 +23,7 @@ pin_project! {
     /// The replication *must* be explicitly completed via the `finish` method.
     pub struct ReplicationStream {
         #[pin]
-        stream: CopyBothDuplex<Bytes>,
+        pub(crate) stream: CopyBothDuplex<Bytes>,
     }
 }
 


### PR DESCRIPTION
Add sync (blocking) wrappers for the async replication API.

I'm not sure how well this works yet. The one unit test is the only testing this code has had.

I'm still a little confused about the function of the `finish` call-- the async code says it must be called, but I don't see any way to call it.

A few other cleanups that should be done:
- The `replication_test.rs` file should probably be merged into `test.rs`.
- Many files have duplicated names across the different crates. It's kind of confusing.
- I'm not convinced that the replication structs should be called `ReplicationIter`/`LogicalReplicationIter`. I'm not sure that `ReplicationStream`/`LogicalReplicationStream` names make sense in the thread-blocking model, and the name collision makes `git grep` much less useful.