### PR TITLE
Add replication stream/sink splitting

### DIFF
--- a/tokio-postgres/src/lib.rs
+++ b/tokio-postgres/src/lib.rs
@@ -119,7 +119,7 @@ pub use crate::cancel_token::CancelToken;
 pub use crate::client::Client;
 pub use crate::config::Config;
 pub use crate::connection::Connection;
-pub use crate::copy_both::CopyBothDuplex;
+pub use crate::copy_both::{CopyBothDuplex, Receiver as CopyBothStream, Sender as CopyBothSink};
 pub use crate::copy_in::CopyInSink;
 pub use crate::copy_out::CopyOutStream;
 use crate::error::DbError;


### PR DESCRIPTION
Builds on top of the replication2 branch, commit 9eb0dbfbeb6a6c1b79099b9f7ae4a8c021877858.

There's some care to be taken when using this, more than the sort of splitting that we have in something like rustls-split. That's been described in more detail in the comment above `CopyBothDuplex::split`.