### PR TITLE
Make tokio-postgres connection parameters public

### DIFF
--- a/tokio-postgres/src/connection.rs
+++ b/tokio-postgres/src/connection.rs
@@ -51,7 +51,8 @@ enum State {
 #[must_use = "futures do nothing unless polled"]
 pub struct Connection<S, T> {
     stream: Framed<MaybeTlsStream<S, T>, PostgresCodec>,
-    parameters: HashMap<String, String>,
+    /// HACK: we need this in the Neon Proxy to forward params.
+    pub parameters: HashMap<String, String>,
     receiver: mpsc::UnboundedReceiver<Request>,
     pending_request: Option<RequestMessages>,
     pending_responses: VecDeque<BackendMessage>,


### PR DESCRIPTION
We need this to enable parameter forwarding in Neon Proxy. This is less than ideal, but we'll probably revert the patch once a proper fix has been implemented.