### PR TITLE
Allow passing null params in query_raw_txt()

### DIFF
--- a/tokio-postgres/src/client.rs
+++ b/tokio-postgres/src/client.rs
@@ -381,7 +381,7 @@ impl Client {
     pub async fn query_raw_txt<'a, S, I>(&self, query: S, params: I) -> Result<RowStream, Error>
     where
         S: AsRef<str>,
-        I: IntoIterator<Item = S>,
+        I: IntoIterator<Item = Option<S>>,
         I::IntoIter: ExactSizeIterator,
     {
         let params = params.into_iter();
@@ -396,9 +396,12 @@ impl Client {
                 "",                 // empty string selects the unnamed prepared statement
                 std::iter::empty(), // all parameters use the default format (text)
                 params,
-                |param, buf| {
-                    buf.put_slice(param.as_ref().as_bytes());
-                    Ok(postgres_protocol::IsNull::No)
+                |param, buf| match param {
+                    Some(param) => {
+                        buf.put_slice(param.as_ref().as_bytes());
+                        Ok(postgres_protocol::IsNull::No)
+                    }
+                    None => Ok(postgres_protocol::IsNull::Yes),
                 },
                 Some(0), // all text
                 buf,

--- a/tokio-postgres/tests/test/main.rs
+++ b/tokio-postgres/tests/test/main.rs
@@ -256,7 +256,7 @@ async fn query_raw_txt() {
     let client = connect("user=postgres").await;
 
     let rows: Vec<tokio_postgres::Row> = client
-        .query_raw_txt("SELECT 55 * $1", ["42"])
+        .query_raw_txt("SELECT 55 * $1", [Some("42")])
         .await
         .unwrap()
         .try_collect()
@@ -268,7 +268,7 @@ async fn query_raw_txt() {
     assert_eq!(res, 55 * 42);
 
     let rows: Vec<tokio_postgres::Row> = client
-        .query_raw_txt("SELECT $1", ["42"])
+        .query_raw_txt("SELECT $1", [Some("42")])
         .await
         .unwrap()
         .try_collect()
@@ -278,6 +278,36 @@ async fn query_raw_txt() {
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].get::<_, &str>(0), "42");
     assert!(rows[0].body_len() > 0);
+}
+
+#[tokio::test]
+async fn query_raw_txt_nulls() {
+    let client = connect("user=postgres").await;
+
+    let rows: Vec<tokio_postgres::Row> = client
+        .query_raw_txt(
+            "SELECT $1 as str, $2 as n, 'null' as str2, null as n2",
+            [Some("null"), None],
+        )
+        .await
+        .unwrap()
+        .try_collect()
+        .await
+        .unwrap();
+
+    assert_eq!(rows.len(), 1);
+
+    let res = rows[0].as_text(0).unwrap();
+    assert_eq!(res, Some("null"));
+
+    let res = rows[0].as_text(1).unwrap();
+    assert_eq!(res, None);
+
+    let res = rows[0].as_text(2).unwrap();
+    assert_eq!(res, Some("null"));
+
+    let res = rows[0].as_text(3).unwrap();
+    assert_eq!(res, None);
 }
 
 #[tokio::test]


### PR DESCRIPTION
Previous coding only allowed passing vector of text values as params, but that does not allow to distinguish between nulls and 4-byte strings with "null" written in them. Change query_raw_txt params argument to accept Vec<Option<String>> instead.