### PR TITLE
Return more RowDescription fields

### DIFF
--- a/tokio-postgres/src/client.rs
+++ b/tokio-postgres/src/client.rs
@@ -449,8 +449,10 @@ impl Client {
         if let Some(row_description) = row_description {
             let mut it = row_description.fields();
             while let Some(field) = it.next().map_err(Error::parse)? {
+                // NB: for some types that function may send a query to the server. At least in
+                // raw text mode we don't need that info and can skip this.
                 let type_ = get_type(&self.inner, field.type_oid()).await?;
-                let column = Column::new(field.name().to_string(), type_);
+                let column = Column::new(field.name().to_string(), type_, field);
                 columns.push(column);
             }
         }

--- a/tokio-postgres/src/prepare.rs
+++ b/tokio-postgres/src/prepare.rs
@@ -95,7 +95,7 @@ pub async fn prepare(
         let mut it = row_description.fields();
         while let Some(field) = it.next().map_err(Error::parse)? {
             let type_ = get_type(client, field.type_oid()).await?;
-            let column = Column::new(field.name().to_string(), type_);
+            let column = Column::new(field.name().to_string(), type_, field);
             columns.push(column);
         }
     }

--- a/tokio-postgres/src/statement.rs
+++ b/tokio-postgres/src/statement.rs
@@ -2,7 +2,10 @@ use crate::client::InnerClient;
 use crate::codec::FrontendMessage;
 use crate::connection::RequestMessages;
 use crate::types::Type;
-use postgres_protocol::message::frontend;
+use postgres_protocol::{
+    message::{backend::Field, frontend},
+    Oid,
+};
 use postgres_types::Format;
 use std::{
     fmt,
@@ -91,11 +94,30 @@ impl Statement {
 pub struct Column {
     name: String,
     type_: Type,
+
+    // raw fields from RowDescription
+    table_oid: Oid,
+    column_id: i16,
+    format: i16,
+
+    // that better be stored in self.type_, but that is more radical refactoring
+    type_oid: Oid,
+    type_size: i16,
+    type_modifier: i32,
 }
 
 impl Column {
-    pub(crate) fn new(name: String, type_: Type) -> Column {
-        Column { name, type_ }
+    pub(crate) fn new(name: String, type_: Type, raw_field: Field<'_>) -> Column {
+        Column {
+            name,
+            type_,
+            table_oid: raw_field.table_oid(),
+            column_id: raw_field.column_id(),
+            format: raw_field.format(),
+            type_oid: raw_field.type_oid(),
+            type_size: raw_field.type_size(),
+            type_modifier: raw_field.type_modifier(),
+        }
     }
 
     /// Returns the name of the column.
@@ -106,6 +128,36 @@ impl Column {
     /// Returns the type of the column.
     pub fn type_(&self) -> &Type {
         &self.type_
+    }
+
+    /// Returns the table OID of the column.
+    pub fn table_oid(&self) -> Oid {
+        self.table_oid
+    }
+
+    /// Returns the column ID of the column.
+    pub fn column_id(&self) -> i16 {
+        self.column_id
+    }
+
+    /// Returns the format of the column.
+    pub fn format(&self) -> i16 {
+        self.format
+    }
+
+    /// Returns the type OID of the column.
+    pub fn type_oid(&self) -> Oid {
+        self.type_oid
+    }
+
+    /// Returns the type size of the column.
+    pub fn type_size(&self) -> i16 {
+        self.type_size
+    }
+
+    /// Returns the type modifier of the column.
+    pub fn type_modifier(&self) -> i32 {
+        self.type_modifier
     }
 }
 

--- a/tokio-postgres/tests/test/main.rs
+++ b/tokio-postgres/tests/test/main.rs
@@ -354,6 +354,31 @@ async fn command_tag() {
 }
 
 #[tokio::test]
+async fn column_extras() {
+    let client = connect("user=postgres").await;
+
+    let rows: Vec<tokio_postgres::Row> = client
+        .query_raw_txt("select relacl, relname from pg_class limit 1", [])
+        .await
+        .unwrap()
+        .try_collect()
+        .await
+        .unwrap();
+
+    let column = rows[0].columns().get(1).unwrap();
+    assert_eq!(column.name(), "relname");
+    assert_eq!(column.type_(), &Type::NAME);
+
+    assert!(column.table_oid() > 0);
+    assert_eq!(column.column_id(), 2);
+    assert_eq!(column.format(), 0);
+
+    assert_eq!(column.type_oid(), 19);
+    assert_eq!(column.type_size(), 64);
+    assert_eq!(column.type_modifier(), -1);
+}
+
+#[tokio::test]
 async fn custom_composite() {
     let client = connect("user=postgres").await;
 


### PR DESCRIPTION
As we are trying to match client-side behaviour with node-postgres we need to return this fields as well because node-postgres returns them.