### PR TITLE
Connection changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       - run: docker compose up -d
       - uses: sfackler/actions/rustup@master
         with:
-          version: 1.65.0
+          version: 1.67.0
       - run: echo "::set-output name=version::$(rustc --version)"
         id: rust-version
       - uses: actions/cache@v1

--- a/tokio-postgres/src/client.rs
+++ b/tokio-postgres/src/client.rs
@@ -376,13 +376,19 @@ impl Client {
 
     /// Pass text directly to the Postgres backend to allow it to sort out typing itself and
     /// to save a roundtrip
-    pub async fn query_raw_txt<'a, S, I>(&self, query: S, params: I) -> Result<RowStream, Error>
+    pub async fn query_raw_txt<'a, T, S, I>(
+        &self,
+        statement: &T,
+        params: I,
+    ) -> Result<RowStream, Error>
     where
-        S: AsRef<str> + Sync + Send,
+        T: ?Sized + ToStatement,
+        S: AsRef<str>,
         I: IntoIterator<Item = Option<S>>,
-        I::IntoIter: ExactSizeIterator + Sync + Send,
+        I::IntoIter: ExactSizeIterator,
     {
-        query::query_txt(&self.inner, query, params).await
+        let statement = statement.__convert().into_statement(self).await?;
+        query::query_txt(&self.inner, statement, params).await
     }
 
     /// Executes a statement, returning the number of rows modified.

--- a/tokio-postgres/src/generic_client.rs
+++ b/tokio-postgres/src/generic_client.rs
@@ -57,8 +57,13 @@ pub trait GenericClient: private::Sealed {
         I::IntoIter: ExactSizeIterator;
 
     /// Like `Client::query_raw_txt`.
-    async fn query_raw_txt<'a, S, I>(&self, query: S, params: I) -> Result<RowStream, Error>
+    async fn query_raw_txt<'a, T, S, I>(
+        &self,
+        statement: &T,
+        params: I,
+    ) -> Result<RowStream, Error>
     where
+        T: ?Sized + ToStatement + Sync + Send,
         S: AsRef<str> + Sync + Send,
         I: IntoIterator<Item = Option<S>> + Sync + Send,
         I::IntoIter: ExactSizeIterator + Sync + Send;
@@ -140,13 +145,14 @@ impl GenericClient for Client {
         self.query_raw(statement, params).await
     }
 
-    async fn query_raw_txt<'a, S, I>(&self, query: S, params: I) -> Result<RowStream, Error>
+    async fn query_raw_txt<'a, T, S, I>(&self, statement: &T, params: I) -> Result<RowStream, Error>
     where
+        T: ?Sized + ToStatement + Sync + Send,
         S: AsRef<str> + Sync + Send,
         I: IntoIterator<Item = Option<S>> + Sync + Send,
         I::IntoIter: ExactSizeIterator + Sync + Send,
     {
-        self.query_raw_txt(query, params).await
+        self.query_raw_txt(statement, params).await
     }
 
     async fn prepare(&self, query: &str) -> Result<Statement, Error> {
@@ -231,13 +237,14 @@ impl GenericClient for Transaction<'_> {
         self.query_raw(statement, params).await
     }
 
-    async fn query_raw_txt<'a, S, I>(&self, query: S, params: I) -> Result<RowStream, Error>
+    async fn query_raw_txt<'a, T, S, I>(&self, statement: &T, params: I) -> Result<RowStream, Error>
     where
+        T: ?Sized + ToStatement + Sync + Send,
         S: AsRef<str> + Sync + Send,
         I: IntoIterator<Item = Option<S>> + Sync + Send,
         I::IntoIter: ExactSizeIterator + Sync + Send,
     {
-        self.query_raw_txt(query, params).await
+        self.query_raw_txt(statement, params).await
     }
 
     async fn prepare(&self, query: &str) -> Result<Statement, Error> {

--- a/tokio-postgres/src/row.rs
+++ b/tokio-postgres/src/row.rs
@@ -98,6 +98,7 @@ where
 /// A row of data returned from the database by a query.
 pub struct Row {
     statement: Statement,
+    output_format: Format,
     body: DataRowBody,
     ranges: Vec<Option<Range<usize>>>,
 }
@@ -111,12 +112,17 @@ impl fmt::Debug for Row {
 }
 
 impl Row {
-    pub(crate) fn new(statement: Statement, body: DataRowBody) -> Result<Row, Error> {
+    pub(crate) fn new(
+        statement: Statement,
+        body: DataRowBody,
+        output_format: Format,
+    ) -> Result<Row, Error> {
         let ranges = body.ranges().collect().map_err(Error::parse)?;
         Ok(Row {
             statement,
             body,
             ranges,
+            output_format,
         })
     }
 
@@ -193,7 +199,7 @@ impl Row {
     ///
     /// Useful when using query_raw_txt() which sets text transfer mode
     pub fn as_text(&self, idx: usize) -> Result<Option<&str>, Error> {
-        if self.statement.output_format() == Format::Text {
+        if self.output_format == Format::Text {
             match self.col_buffer(idx) {
                 Some(raw) => {
                     FromSql::from_sql(&Type::TEXT, raw).map_err(|e| Error::from_sql(e, idx))

--- a/tokio-postgres/src/statement.rs
+++ b/tokio-postgres/src/statement.rs
@@ -6,7 +6,6 @@ use postgres_protocol::{
     message::{backend::Field, frontend},
     Oid,
 };
-use postgres_types::Format;
 use std::{
     fmt,
     sync::{Arc, Weak},
@@ -17,7 +16,6 @@ struct StatementInner {
     name: String,
     params: Vec<Type>,
     columns: Vec<Column>,
-    output_format: Format,
 }
 
 impl Drop for StatementInner {
@@ -51,22 +49,6 @@ impl Statement {
             name,
             params,
             columns,
-            output_format: Format::Binary,
-        }))
-    }
-
-    pub(crate) fn new_text(
-        inner: &Arc<InnerClient>,
-        name: String,
-        params: Vec<Type>,
-        columns: Vec<Column>,
-    ) -> Statement {
-        Statement(Arc::new(StatementInner {
-            client: Arc::downgrade(inner),
-            name,
-            params,
-            columns,
-            output_format: Format::Text,
         }))
     }
 
@@ -82,11 +64,6 @@ impl Statement {
     /// Returns information about the columns returned when the statement is queried.
     pub fn columns(&self) -> &[Column] {
         &self.0.columns
-    }
-
-    /// Returns output format for the statement.
-    pub fn output_format(&self) -> Format {
-        self.0.output_format
     }
 }
 

--- a/tokio-postgres/src/transaction.rs
+++ b/tokio-postgres/src/transaction.rs
@@ -150,13 +150,14 @@ impl<'a> Transaction<'a> {
     }
 
     /// Like `Client::query_raw_txt`.
-    pub async fn query_raw_txt<S, I>(&self, query: S, params: I) -> Result<RowStream, Error>
+    pub async fn query_raw_txt<T, S, I>(&self, statement: &T, params: I) -> Result<RowStream, Error>
     where
-        S: AsRef<str> + Sync + Send,
+        T: ?Sized + ToStatement,
+        S: AsRef<str>,
         I: IntoIterator<Item = Option<S>>,
-        I::IntoIter: ExactSizeIterator + Sync + Send,
+        I::IntoIter: ExactSizeIterator,
     {
-        self.client.query_raw_txt(query, params).await
+        self.client.query_raw_txt(statement, params).await
     }
 
     /// Like `Client::execute`.

--- a/tokio-postgres/tests/test/main.rs
+++ b/tokio-postgres/tests/test/main.rs
@@ -314,7 +314,7 @@ async fn query_raw_txt_nulls() {
 async fn limit_max_backend_message_size() {
     let client = connect("user=postgres max_backend_message_size=10000").await;
     let small: Vec<tokio_postgres::Row> = client
-        .query_raw_txt("SELECT REPEAT('a', 20)", [])
+        .query_raw_txt("SELECT REPEAT('a', 20)", [] as [Option<&str>; 0])
         .await
         .unwrap()
         .try_collect()
@@ -325,7 +325,7 @@ async fn limit_max_backend_message_size() {
     assert_eq!(small[0].as_text(0).unwrap().unwrap().len(), 20);
 
     let large: Result<Vec<tokio_postgres::Row>, Error> = client
-        .query_raw_txt("SELECT REPEAT('a', 2000000)", [])
+        .query_raw_txt("SELECT REPEAT('a', 2000000)", [] as [Option<&str>; 0])
         .await
         .unwrap()
         .try_collect()
@@ -339,7 +339,7 @@ async fn command_tag() {
     let client = connect("user=postgres").await;
 
     let row_stream = client
-        .query_raw_txt("select unnest('{1,2,3}'::int[]);", [])
+        .query_raw_txt("select unnest('{1,2,3}'::int[]);", [] as [Option<&str>; 0])
         .await
         .unwrap();
 
@@ -358,7 +358,10 @@ async fn column_extras() {
     let client = connect("user=postgres").await;
 
     let rows: Vec<tokio_postgres::Row> = client
-        .query_raw_txt("select relacl, relname from pg_class limit 1", [])
+        .query_raw_txt(
+            "select relacl, relname from pg_class limit 1",
+            [] as [Option<&str>; 0],
+        )
         .await
         .unwrap()
         .try_collect()

--- a/tokio-postgres/tests/test/main.rs
+++ b/tokio-postgres/tests/test/main.rs
@@ -354,6 +354,31 @@ async fn command_tag() {
 }
 
 #[tokio::test]
+async fn ready_for_query() {
+    let client = connect("user=postgres").await;
+
+    let row_stream = client
+        .query_raw_txt("START TRANSACTION", [] as [Option<&str>; 0])
+        .await
+        .unwrap();
+
+    pin_mut!(row_stream);
+    while row_stream.next().await.is_none() {}
+
+    assert_eq!(row_stream.ready_status(), Some(b'T'));
+
+    let row_stream = client
+        .query_raw_txt("ROLLBACK", [] as [Option<&str>; 0])
+        .await
+        .unwrap();
+
+    pin_mut!(row_stream);
+    while row_stream.next().await.is_none() {}
+
+    assert_eq!(row_stream.ready_status(), Some(b'I'));
+}
+
+#[tokio::test]
 async fn column_extras() {
     let client = connect("user=postgres").await;
 


### PR DESCRIPTION
1. refactor query_raw_txt to use a pre-prepared statement

Doing type checking during the query is a bug as connection will end up reading in all rows from the response before any of the types get returned. this diminished the usefulness of the stream interface entirely.

2. track `ReadyForQuery` on the connection and expose it on the clients

I want to remove tokio-postgres entirely in proxy soon, but looks like it will need more time and we want the transaction status checking sooner than that. So this is a stop gap. I don't like half measures but this will have to do.