### PR TITLE
make CopyBothDuplex struct `pub`

### DIFF
--- a/tokio-postgres/src/lib.rs
+++ b/tokio-postgres/src/lib.rs
@@ -124,6 +124,7 @@ pub use crate::cancel_token::CancelToken;
 pub use crate::client::Client;
 pub use crate::config::Config;
 pub use crate::connection::Connection;
+pub use crate::copy_both::CopyBothDuplex;
 pub use crate::copy_in::CopyInSink;
 pub use crate::copy_out::CopyOutStream;
 use crate::error::DbError;


### PR DESCRIPTION
This is useful / needed to build a Rust client for the Pageserver's
GetPage@LSN API, which uses CopyBoth mode.