### PR TITLE
backend: pack next record LSN into the encoded message

### DIFF
--- a/postgres-protocol/src/message/backend.rs
+++ b/postgres-protocol/src/message/backend.rs
@@ -375,15 +375,10 @@ impl ReplicationMessage<Bytes> {
             INTERPRETED_WAL_RECORD_TAG => {
                 let streaming_lsn = buf.read_u64::<BigEndian>()?;
                 let commit_lsn = buf.read_u64::<BigEndian>()?;
-                let next_record_lsn = match buf.read_u64::<BigEndian>()? {
-                    0 => None,
-                    lsn => Some(lsn),
-                };
 
                 ReplicationMessage::RawInterpretedWalRecords(RawInterpretedWalRecordsBody {
                     streaming_lsn,
                     commit_lsn,
-                    next_record_lsn,
                     data: buf.read_all(),
                 })
             }
@@ -971,7 +966,6 @@ impl<D> XLogDataBody<D> {
 pub struct RawInterpretedWalRecordsBody<D> {
     streaming_lsn: u64,
     commit_lsn: u64,
-    next_record_lsn: Option<u64>,
     data: D,
 }
 
@@ -984,11 +978,6 @@ impl<D> RawInterpretedWalRecordsBody<D> {
     #[inline]
     pub fn commit_lsn(&self) -> u64 {
         self.commit_lsn
-    }
-
-    #[inline]
-    pub fn next_record_lsn(&self) -> Option<u64> {
-        self.next_record_lsn
     }
 
     #[inline]


### PR DESCRIPTION
This field only needs to be read after the batch is decoded, so we can move into the body to get more efficient encoding.